### PR TITLE
fix(production config)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,0 +1,12 @@
+{
+  "redis": {
+    "redisUrl": "REDIS_URL"
+  },
+  "slack": {
+    "railtie": {
+      "channel": "SLACK_CHANNEL",
+      "token": "SLACK_BOT_TOKEN",
+      "verificationToken": "SLACK_VERIFICATION_TOKEN"
+    }
+  }
+}


### PR DESCRIPTION
apparently custom environment variables need to be in their own file,
following proper structure from `production.json` or some other
`env.json` config file.

I'll leave production.json alone since the file is required to be there
to boot...