### PR TITLE
fix(heroku port)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,8 @@ const slackConfig = config.get("slack")
 
 app.start = async () => {
   const port = config.get("port")
-  console.log("starting at server at port", port)
-  app.set("port", port)
+  console.log("starting at server at port", process.env.PORT || port)
+  app.set("port", process.env.PORT || port)
   app.use(bodyParser.urlencoded({extended: true}))
   app.use(bodyParser.json())
 


### PR DESCRIPTION
heroku cannot set port based on a fixed num, but heroku DOES add the
port to env when starting; so this checks if the env has a PORT, or
defaults to the config we have.