### PR TITLE
feat(scheduler) codify scheduler component

### DIFF
--- a/src/prepare-train.js
+++ b/src/prepare-train.js
@@ -1,9 +1,15 @@
+const moment = require("moment")
+require("moment-timezone")
+
+if (moment().tz("America/Los_Angeles").day() !== 3) {
+  console.log("attempted to run scheduler, exiting because !Wednesday")
+  process.exit(0)
+}
+
 const redisClient = require("./redisClient")
 const fetch = require("node-fetch")
 const slackConfig = require("config").get("slack")
 const slackClient = require("./slackClient")
-const moment = require("moment")
-require("moment-timezone")
 
 // 1:30pm
 const departureTime = moment(process.argv[2], "h:mma").tz("America/Los_Angeles")

--- a/src/start-train.js
+++ b/src/start-train.js
@@ -1,3 +1,11 @@
+const moment = require("moment")
+require("moment-timezone")
+
+if (moment().tz("America/Los_Angeles").day() !== 3) {
+  console.log("attempted to run scheduler, exiting because !Wednesday")
+  process.exit(0)
+}
+
 const redisClient = require("./redisClient")
 const slackClient = require("./slackClient")
 const messageBuilder = require("./messageBuilder")


### PR DESCRIPTION
To keep things simple, we want to use Heroku Scheduler. Unfortunately,
that scheduler has very limited control over actual scheduling. This
codifies Wednesday as the day we wish to run the Team Train.

On Heroku Scheduler, there will be 4 corresponding jobs that run daily
at the proper time, but this will catch and exit if it isn't Wednesday.