### PR TITLE
Remove .babelrc from root node

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,0 @@
-{
-  "presets": [
-    ["env", {
-      "targets": {
-        "node": "current"
-      }
-    }]
-  ]
-}


### PR DESCRIPTION
## What

Removes `.babelrc` from root node.

## Why

We removed babel to be able to run safely on heroku with CLI and web components. This is an old remnant that we likely don't need anymore.
